### PR TITLE
mvcc: add metrics to characterize backend expensive reads

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -304,6 +304,7 @@ func (b *backend) SizeInUse() int64 {
 func (b *backend) run() {
 	defer close(b.donec)
 	t := time.NewTimer(b.batchInterval)
+	start := time.Now()
 	defer t.Stop()
 	for {
 		select {
@@ -315,6 +316,8 @@ func (b *backend) run() {
 		if b.batchTx.safePending() != 0 {
 			b.batchTx.Commit()
 		}
+		batchIntervalSec.Observe(time.Since(start).Seconds())
+		start = time.Now()
 		t.Reset(b.batchInterval)
 		b.createConcurrentReadTxs()
 	}

--- a/mvcc/backend/metrics.go
+++ b/mvcc/backend/metrics.go
@@ -83,6 +83,17 @@ var (
 		// highest bucket start of 0.01 sec * 2^16 == 655.36 sec
 		Buckets: prometheus.ExponentialBuckets(.01, 2, 17),
 	})
+
+	batchIntervalSec = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "backend",
+		Name:      "batch_interval_duration_Seconds",
+		Help:      "The distributions of batch interval in mvcc backend.",
+
+		// lowest bucket start of upper bound 0.0001 sec (0.1 msec) with factor 2
+		// highest bucket start of 0.1 msec * 2^13 == 0.8192 sec
+		Buckets: prometheus.ExponentialBuckets(0.0001, 2, 14),
+	})
 )
 
 func init() {
@@ -92,4 +103,5 @@ func init() {
 	prometheus.MustRegister(writeSec)
 	prometheus.MustRegister(defragSec)
 	prometheus.MustRegister(snapshotTransferSec)
+	prometheus.MustRegister(batchIntervalSec)
 }

--- a/mvcc/kv.go
+++ b/mvcc/kv.go
@@ -57,6 +57,7 @@ type ReadView interface {
 type TxnRead interface {
 	ReadView
 	// End marks the transaction is complete and ready to commit.
+	IsCommittedRead() bool
 	End()
 }
 

--- a/mvcc/metrics.go
+++ b/mvcc/metrics.go
@@ -217,6 +217,49 @@ var (
 		// highest bucket start of 0.01 sec * 2^14 == 163.84 sec
 		Buckets: prometheus.ExponentialBuckets(.01, 2, 15),
 	})
+
+	committedReadCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "etcd_debugging",
+			Subsystem: "mvcc",
+			Name:      "committed_read_total",
+			Help:      "Total number of committed read.",
+		})
+
+
+
+	rangeSec = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "mvcc",
+		Name:      "range_duration_seconds",
+		Help:      "The latency distributions of range in mvcc store.",
+
+		// lowest bucket start of upper bound 0.00001 sec (0.01 msec) with factor 2
+		// highest bucket start of 0.01 msec * 2^13 == 8.192 sec
+		Buckets: prometheus.ExponentialBuckets(0.00001, 2, 14),
+	})
+
+	putSec = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "mvcc",
+		Name:      "put_duration_seconds",
+		Help:      "The latency distributions of put in mvcc store.",
+
+		// lowest bucket start of upper bound 0.00001 sec (0.01 msec) with factor 2
+		// highest bucket start of 0.01 msec * 2^13 == 81.92 msec
+		Buckets: prometheus.ExponentialBuckets(0.00001, 2, 14),
+	})
+
+	committedReadSec = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "mvcc",
+		Name:      "committed_read_duration_seconds",
+		Help:      "The latency distributions of committed read in mvcc store.",
+
+		// lowest bucket start of upper bound 0.00001 sec (0.01 msec) with factor 2
+		// highest bucket start of 0.01 msec * 2^15 == 327.68 msec
+		Buckets: prometheus.ExponentialBuckets(0.00001, 2, 16),
+	})
 )
 
 func init() {
@@ -239,6 +282,10 @@ func init() {
 	prometheus.MustRegister(dbTotalSizeInUse)
 	prometheus.MustRegister(hashSec)
 	prometheus.MustRegister(hashRevSec)
+	prometheus.MustRegister(committedReadCounter)
+	prometheus.MustRegister(rangeSec)
+	prometheus.MustRegister(putSec)
+	prometheus.MustRegister(committedReadSec)
 }
 
 // ReportEventReceived reports that an event is received.


### PR DESCRIPTION
Metrics added:

etcd_debugging_mvcc_put_total
etcd_debugging_mvcc_put_duration_seconds
etcd_debugging_mvcc_range_total
etcd_debugging_mvcc_range_duration_seconds
etcd_debugging_mvcc_committed_read_total
etcd_debugging_mvcc_committed_read_duration_seconds
etcd_debugging_backend_batch_interval_duration_seconds
