### PR TITLE
*: add flag for backend expensive read limit

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -75,6 +75,8 @@ const (
 	// maxElectionMs specifies the maximum value of election timeout.
 	// More details are listed in ../Documentation/tuning.md#time-parameters.
 	maxElectionMs = 50000
+
+	DefaultBackendExpensiveReadLimit = 1000
 )
 
 var (
@@ -270,9 +272,10 @@ type Config struct {
 	AuthToken  string `json:"auth-token"`
 	BcryptCost uint   `json:"bcrypt-cost"`
 
-	ExperimentalInitialCorruptCheck bool          `json:"experimental-initial-corrupt-check"`
-	ExperimentalCorruptCheckTime    time.Duration `json:"experimental-corrupt-check-time"`
-	ExperimentalEnableV2V3          string        `json:"experimental-enable-v2v3"`
+	ExperimentalInitialCorruptCheck       bool          `json:"experimental-initial-corrupt-check"`
+	ExperimentalCorruptCheckTime          time.Duration `json:"experimental-corrupt-check-time"`
+	ExperimentalEnableV2V3                string        `json:"experimental-enable-v2v3"`
+	ExperimentalBackendExpensiveReadLimit int           `json:"experimental-backend-expensive-read-limit"`
 
 	// ForceNewCluster starts a new cluster even if previously started; unsafe.
 	ForceNewCluster bool `json:"force-new-cluster"`

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -201,6 +201,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		Debug:                      cfg.Debug,
 		ForceNewCluster:            cfg.ForceNewCluster,
 		EnableGRPCGateway:          cfg.EnableGRPCGateway,
+		BackendExpensiveReadLimit:  cfg.ExperimentalBackendExpensiveReadLimit,
 	}
 	print(e.cfg.logger, *cfg, srvcfg, memberInitialized)
 	if e.Server, err = etcdserver.NewServer(srvcfg); err != nil {

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -248,6 +248,7 @@ func newConfig() *config {
 	fs.BoolVar(&cfg.ec.ExperimentalInitialCorruptCheck, "experimental-initial-corrupt-check", cfg.ec.ExperimentalInitialCorruptCheck, "Enable to check data corruption before serving any client/peer traffic.")
 	fs.DurationVar(&cfg.ec.ExperimentalCorruptCheckTime, "experimental-corrupt-check-time", cfg.ec.ExperimentalCorruptCheckTime, "Duration of time between cluster corruption check passes.")
 	fs.StringVar(&cfg.ec.ExperimentalEnableV2V3, "experimental-enable-v2v3", cfg.ec.ExperimentalEnableV2V3, "v3 prefix for serving emulated v2 state.")
+	fs.IntVar(&cfg.ec.ExperimentalBackendExpensiveReadLimit, "experimental-backend-expensive-read-limit", embed.DefaultBackendExpensiveReadLimit, "The number of keys in expensive read request in etcd backend")
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -200,6 +200,8 @@ Experimental feature:
     Duration of time between cluster corruption check passes.
   --experimental-enable-v2v3 ''
     Serve v2 requests through the v3 backend under a given prefix.
+  --experimental-backend-expensive-read-limit '1000'
+    The number of keys in expensive read request in etcd backend
 
 Unsafe feature:
   --force-new-cluster 'false'

--- a/etcdserver/backend.go
+++ b/etcdserver/backend.go
@@ -48,6 +48,7 @@ func newBackend(cfg ServerConfig) backend.Backend {
 		// permit 10% excess over quota for disarm
 		bcfg.MmapSize = uint64(cfg.QuotaBackendBytes + cfg.QuotaBackendBytes/10)
 	}
+	bcfg.ExpensiveReadLimit = cfg.BackendExpensiveReadLimit
 	return backend.New(bcfg)
 }
 

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -150,6 +150,8 @@ type ServerConfig struct {
 	LeaseCheckpointInterval time.Duration
 
 	EnableGRPCGateway bool
+
+	BackendExpensiveReadLimit int
 }
 
 // VerifyBootstrap sanity-checks the initial config for bootstrap case


### PR DESCRIPTION
flag added:
--experimental-backend-expensive-read-limit

Backend has a config file, which can be used to pass the flag value.  Ideally, mvcc.kvstore should also have a config file.
